### PR TITLE
`LoadSettingsAsync` now takes a `Dictionary`

### DIFF
--- a/src/MauiSettings/Helper/MauiSettingsHelper.cs
+++ b/src/MauiSettings/Helper/MauiSettingsHelper.cs
@@ -58,7 +58,13 @@ namespace AndreasReitberger.Maui.Helper
                     }
                     break;
             }
-            return (T)Convert.ChangeType(returnValue, typeof(T));
+            return ChangeSettingsType<T>(returnValue, defaultValue);
+            //return (T)Convert.ChangeType(returnValue, typeof(T));
+        }
+
+        public static T ChangeSettingsType<T>(object settingsValue, T defaultValue)
+        {
+            return (T)Convert.ChangeType(settingsValue, typeof(T));
         }
 
         // Docs: https://docs.microsoft.com/en-us/dotnet/maui/platform-integration/storage/secure-storage?tabs=ios


### PR DESCRIPTION
This PR extends the `LoadSettingsAsync` method to also load the data from a `Dictionary`.

Fixed #15