### PR TITLE
Fixed bug if `DefaultValue` and `SettingsType` did not match

### DIFF
--- a/src/MauiSettings.Example/AppShell.xaml
+++ b/src/MauiSettings.Example/AppShell.xaml
@@ -4,12 +4,17 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:MauiSettings.Example"
-    Shell.FlyoutBehavior="Disabled"
+    Shell.FlyoutBehavior="Flyout"
     Title="MauiSettings.Example">
 
     <ShellContent
         Title="Home"
         ContentTemplate="{DataTemplate local:MainPage}"
         Route="MainPage" />
+
+    <ShellContent
+        Title="Settings"
+        ContentTemplate="{DataTemplate local:SettingsPage}"
+        Route="SettingsPage" />
 
 </Shell>

--- a/src/MauiSettings.Example/MauiSettings.Example.csproj
+++ b/src/MauiSettings.Example/MauiSettings.Example.csproj
@@ -66,4 +66,16 @@
 	  <ProjectReference Include="..\MauiSettings\MauiSettings.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Compile Update="SettingsPage.xaml.cs">
+	    <DependentUpon>SettingsPage.xaml</DependentUpon>
+	  </Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <MauiXaml Update="SettingsPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	</ItemGroup>
+
 </Project>

--- a/src/MauiSettings.Example/MauiSettings.Example.csproj
+++ b/src/MauiSettings.Example/MauiSettings.Example.csproj
@@ -57,8 +57,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.1" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.82" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.82" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.90" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 

--- a/src/MauiSettings.Example/Models/Settings/SettingsApp.cs
+++ b/src/MauiSettings.Example/Models/Settings/SettingsApp.cs
@@ -38,6 +38,9 @@ namespace MauiSettings.Example.Models.Settings
         [MauiSetting(Name = nameof(App_SettingsVersion), DefaultValue = "1.0.0", SkipForExport = true)]
         public static Version App_SettingsVersion { get; set; }
 
+        [MauiSetting(Name = nameof(ResourcesCurrentVersionAvailable))]
+        public static string ResourcesCurrentVersionAvailable { get; set; } = string.Empty;
+
         #endregion
 
         #region Default

--- a/src/MauiSettings.Example/Models/Settings/SettingsApp.cs
+++ b/src/MauiSettings.Example/Models/Settings/SettingsApp.cs
@@ -61,6 +61,21 @@ namespace MauiSettings.Example.Models.Settings
 
         #endregion
 
+        #region Misc
+
+        [MauiSetting(Name = nameof(Misc_Boolean), DefaultValue = false)]
+        public static bool Misc_Boolean { get; set; }
+
+        [MauiSetting(Name = nameof(Misc_String))]
+        public static string Misc_String { get; set; } = string.Empty;
+
+        [MauiSetting(Name = nameof(Misc_Numeric), DefaultValue = 0)]
+        public static double Misc_Numeric { get; set; } = 0;
+
+        [MauiSetting(Name = nameof(Misc_Counter))]
+        public static int Misc_Counter { get; set; } = 0;
+        #endregion
+
         #endregion
 
         #region Methods

--- a/src/MauiSettings.Example/SettingsPage.xaml
+++ b/src/MauiSettings.Example/SettingsPage.xaml
@@ -13,12 +13,31 @@
             Padding="30,0"
             Spacing="25">
             <Label
-                Text="Enter some text"
+                Text="Settings"
                 Style="{StaticResource Headline}"
                 SemanticProperties.HeadingLevel="Level1"
                 />
+            <Label
+                Text="Enter some text value"
+                Style="{StaticResource SubHeadline}"
+                SemanticProperties.HeadingLevel="Level2"
+                />
             <Editor
                 Text="{Binding CurrentVersionAvailable}"
+                />
+            <Label
+                Text="Enter some bool value"
+                Style="{StaticResource SubHeadline}"
+                SemanticProperties.HeadingLevel="Level2"
+                />
+            <Switch
+                Toggled="{Binding SomeBoolValue}"
+                />
+
+            <BoxView
+                Margin="10,20"
+                HeightRequest="2"
+                Background="{DynamicResource Primary}"
                 />
             <Button
                 x:Name="SaveBtn"

--- a/src/MauiSettings.Example/SettingsPage.xaml
+++ b/src/MauiSettings.Example/SettingsPage.xaml
@@ -23,7 +23,7 @@
                 SemanticProperties.HeadingLevel="Level2"
                 />
             <Editor
-                Text="{Binding CurrentVersionAvailable}"
+                Text="{Binding SomeTextValue}"
                 />
             <Label
                 Text="Enter some bool value"
@@ -31,9 +31,44 @@
                 SemanticProperties.HeadingLevel="Level2"
                 />
             <Switch
-                Toggled="{Binding SomeBoolValue}"
+                IsToggled="{Binding SomeBoolValue}"
                 />
 
+            <Label
+                Text="Enter some numeric value"
+                Style="{StaticResource SubHeadline}"
+                SemanticProperties.HeadingLevel="Level2"
+                />
+            <Editor
+                Text="{Binding SomeDoubleValue}"
+                Keyboard="Numeric"
+                />
+
+            <Label
+                Text="Enter some integer value"
+                Style="{StaticResource SubHeadline}"
+                SemanticProperties.HeadingLevel="Level2"
+                />
+            <Label
+                Text="{Binding SomeIntValue}"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                />
+            <Grid
+                ColumnDefinitions="*,*"
+                >
+                <Button
+                    Margin="8,4"
+                    Text="+1"
+                    Command="{Binding ButtonCountUpCommand}"
+                    />
+                <Button
+                    Margin="8,4"
+                    Grid.Column="1"
+                    Text="-1"
+                    Command="{Binding ButtonCountDownCommand}"
+                    />
+            </Grid>
             <BoxView
                 Margin="10,20"
                 HeightRequest="2"

--- a/src/MauiSettings.Example/SettingsPage.xaml
+++ b/src/MauiSettings.Example/SettingsPage.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="MauiSettings.Example.SettingsPage"
+    xmlns:viewModels="clr-namespace:MauiSettings.Example.ViewModels"
+    xmlns:settings="clr-namespace:MauiSettings.Example.Models.Settings"
+    x:DataType="viewModels:SettingsPageViewModel"
+    >
+
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,0"
+            Spacing="25">
+            <Label
+                Text="Enter some text"
+                Style="{StaticResource Headline}"
+                SemanticProperties.HeadingLevel="Level1"
+                />
+            <Editor
+                Text="{Binding CurrentVersionAvailable}"
+                />
+            <Button
+                x:Name="SaveBtn"
+                Text="Save Settings"
+                Command="{Binding SaveSettingsCommand}"
+                HorizontalOptions="Fill" 
+                />
+            <Button
+                x:Name="LoadBtn"
+                Text="Load Settings"
+                Command="{Binding LoadSettingsFromDeviceCommand}"
+                HorizontalOptions="Fill" 
+                />
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/MauiSettings.Example/SettingsPage.xaml.cs
+++ b/src/MauiSettings.Example/SettingsPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using MauiSettings.Example.ViewModels;
+
+namespace MauiSettings.Example
+{
+    public partial class SettingsPage : ContentPage
+    {
+        public SettingsPage()
+        {
+            InitializeComponent();
+            BindingContext = new SettingsPageViewModel();
+        }
+    }
+
+}

--- a/src/MauiSettings.Example/ViewModels/MainPageViewModel.cs
+++ b/src/MauiSettings.Example/ViewModels/MainPageViewModel.cs
@@ -50,7 +50,7 @@ namespace MauiSettings.Example.ViewModels
 
         #region Commands
         [RelayCommand]
-        async Task SaveSettings() => await SettingsApp.SaveSettingsAsync(key: App.Hash);
+        static async Task SaveSettings() => await SettingsApp.SaveSettingsAsync(key: App.Hash);
 
         [RelayCommand]
         async Task LoadSettingsFromDevice()

--- a/src/MauiSettings.Example/ViewModels/SettingsPageViewModel.cs
+++ b/src/MauiSettings.Example/ViewModels/SettingsPageViewModel.cs
@@ -1,0 +1,60 @@
+﻿using AndreasReitberger.Shared.Core.Utilities;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using MauiSettings.Example.Models.Settings;
+using System.Collections.ObjectModel;
+
+namespace MauiSettings.Example.ViewModels
+{
+    public partial class SettingsPageViewModel : ObservableObject
+    {
+        #region Settings
+        [ObservableProperty]
+        bool isLoading = false;
+
+        [ObservableProperty]
+        string currentVersionAvailable = string.Empty;
+        #endregion
+
+        #region Ctor
+        public SettingsPageViewModel()
+        {
+            LoadSettings();
+        }
+        #endregion
+
+        #region Methods
+        void LoadSettings()
+        {
+            IsLoading = true;
+
+            CurrentVersionAvailable = SettingsApp.ResourcesCurrentVersionAvailable;
+
+            IsLoading = false;
+        }
+        #endregion
+
+        #region Commands
+        [RelayCommand]
+        void SaveSettings()
+        {
+            SettingsApp.ResourcesCurrentVersionAvailable = CurrentVersionAvailable;
+            SettingsApp.SaveSettings();
+        }
+
+        [RelayCommand]
+        void LoadSettingsFromDevice()
+        {
+            try
+            {
+                SettingsApp.LoadSettings();
+                LoadSettings();
+            }
+            catch (Exception)
+            {
+                // Throus if the key missmatches
+            }
+        }
+        #endregion
+    }
+}

--- a/src/MauiSettings.Example/ViewModels/SettingsPageViewModel.cs
+++ b/src/MauiSettings.Example/ViewModels/SettingsPageViewModel.cs
@@ -14,6 +14,15 @@ namespace MauiSettings.Example.ViewModels
 
         [ObservableProperty]
         string currentVersionAvailable = string.Empty;
+
+        [ObservableProperty]
+        int someIntValue = 93216;
+
+        [ObservableProperty]
+        double someDoubleValue = 2651.65;
+
+        [ObservableProperty]
+        bool someBoolValue = true;
         #endregion
 
         #region Ctor

--- a/src/MauiSettings.Example/ViewModels/SettingsPageViewModel.cs
+++ b/src/MauiSettings.Example/ViewModels/SettingsPageViewModel.cs
@@ -1,8 +1,6 @@
-﻿using AndreasReitberger.Shared.Core.Utilities;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MauiSettings.Example.Models.Settings;
-using System.Collections.ObjectModel;
 
 namespace MauiSettings.Example.ViewModels
 {
@@ -14,6 +12,9 @@ namespace MauiSettings.Example.ViewModels
 
         [ObservableProperty]
         string currentVersionAvailable = string.Empty;
+
+        [ObservableProperty]
+        string someTextValue = "Example text incoming...";
 
         [ObservableProperty]
         int someIntValue = 93216;
@@ -39,30 +40,55 @@ namespace MauiSettings.Example.ViewModels
 
             CurrentVersionAvailable = SettingsApp.ResourcesCurrentVersionAvailable;
 
+            SomeBoolValue= SettingsApp.Misc_Boolean;
+            SomeDoubleValue = SettingsApp.Misc_Numeric;
+            SomeTextValue = SettingsApp.Misc_String;
+            SomeIntValue = SettingsApp.Misc_Counter;
+
             IsLoading = false;
         }
         #endregion
 
         #region Commands
         [RelayCommand]
-        void SaveSettings()
+        async Task SaveSettings()
         {
             SettingsApp.ResourcesCurrentVersionAvailable = CurrentVersionAvailable;
+            SettingsApp.Misc_Boolean = SomeBoolValue;
+            SettingsApp.Misc_Numeric = SomeDoubleValue;
+            SettingsApp.Misc_String = SomeTextValue;
+            SettingsApp.Misc_Counter = SomeIntValue;
+
             SettingsApp.SaveSettings();
+
+            await Shell.Current.DisplayAlert("Settings saved", "Settings saved successfully...", "OK");
         }
 
         [RelayCommand]
-        void LoadSettingsFromDevice()
+        async Task LoadSettingsFromDevice()
         {
             try
             {
                 SettingsApp.LoadSettings();
                 LoadSettings();
+                await Shell.Current.DisplayAlert("Settings loaded", "Settings loaded successfully...", "OK");
             }
             catch (Exception)
             {
                 // Throus if the key missmatches
             }
+        }
+
+        [RelayCommand]
+        void ButtonCountUp()
+        {
+            SomeIntValue += 1;
+        }
+
+        [RelayCommand]
+        void ButtonCountDown()
+        {
+            SomeIntValue -= 1;
         }
         #endregion
     }

--- a/src/MauiSettings/MauiSettings.csproj
+++ b/src/MauiSettings/MauiSettings.csproj
@@ -29,8 +29,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.82" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.82" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.90" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="SharedNetCoreLibrary" Version="1.1.11" />
 	</ItemGroup>

--- a/src/MauiSettings/MauiSettingsGeneric.cs
+++ b/src/MauiSettings/MauiSettingsGeneric.cs
@@ -527,7 +527,8 @@ namespace AndreasReitberger.Maui
 #endif
                     case MauiSettingsTarget.Local:
                     default:
-                        settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.Default);
+                        //settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.Default);
+                        settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.SettingsType, settingsInfo.Default);
                         break;
 
                 }
@@ -702,7 +703,8 @@ namespace AndreasReitberger.Maui
                         case MauiSettingsTarget.Local:
                         default:
                             if (!useValueFromSettingsInfo)
-                                settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.Default);
+                                //settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.Default);
+                                settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.SettingsType, settingsInfo.Default);
                             else
                                 settingsInfo.Value = MauiSettingsHelper.ChangeSettingsType(settingsInfo.Value, settingsInfo.Default);
                             break;
@@ -993,7 +995,8 @@ namespace AndreasReitberger.Maui
                     // If only secure storage should be loaded, stop here.
                     if (secureOnly)
                         return null;
-                    settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.Default);
+                    //settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.Default);
+                    settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.SettingsType, settingsInfo.Default);
                 }
                 else if (settingsInfo.SettingsType == typeof(string))
                 {


### PR DESCRIPTION
This PR fixes a bug, when the `DefaultValue` was set as `Integer`, but the the `SettingsType` actually was a `Double` or any other numeric data type.

This did not work because the `DefaultValue = 0` was interpreted as `Integer`.
```cs
[MauiSetting(Name = nameof(Misc_Numeric), DefaultValue = 0)]
public static double Misc_Numeric { get; set; } = 0;
```

Workaround was to set the `DefaultValue` to a matching data type.
```cs
[MauiSetting(Name = nameof(Misc_Numeric), DefaultValue = 0d)]
public static double Misc_Numeric { get; set; } = 0;
```

Now, the library uses the `SettingsType`  property if the default value does not match the data type.

```cs
if (targetType != defaultValue?.GetType())
{
     defaultValue = (T?)MauiSettingsObjectHelper.GetTypeDefaultValue(targetType);
}
```

Maybe fixed #56 
