### PR TITLE
Removed `Microsoft.Maui.Controls.Compatibility`

### DIFF
--- a/common.props
+++ b/common.props
@@ -14,7 +14,7 @@
         <Authors>Andreas Reitberger</Authors>
         <Company>Andreas Reitberger</Company>
         <Copyright>Andreas Reitberger</Copyright>
-		<LangVersion>12</LangVersion>
+		<LangVersion>Preview</LangVersion>
 		<Nullable>enable</Nullable>
 		
         <!--Source-Linking-->
@@ -31,9 +31,8 @@
    </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.22" />
-	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.22" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.60" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.4" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/MauiSettings/MauiSettings.csproj
+++ b/src/MauiSettings/MauiSettings.csproj
@@ -21,7 +21,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="SharedNetCoreLibrary" Version="1.1.13" />
+		<PackageReference Include="SharedNetCoreLibrary" Version="1.1.15" />
 	</ItemGroup>
-
 </Project>

--- a/src/MauiSettings/MauiSettingsGeneric.cs
+++ b/src/MauiSettings/MauiSettingsGeneric.cs
@@ -38,7 +38,7 @@ namespace AndreasReitberger.Maui
 
         #region Variables
 
-        static readonly object lockObject = new();
+        static readonly Lock lockObject = new();
         #endregion
 
         #region Properties
@@ -341,9 +341,8 @@ namespace AndreasReitberger.Maui
             {
                 // Get all member infos from the passed settingsObject
                 IEnumerable<MemberInfo>? declaredMembers = settings?.GetType().GetTypeInfo().DeclaredMembers;
-
-                MauiSettingsMemberInfo settingsObjectInfo = new();
-                MauiSettingsInfo settingsInfo = new();
+                //MauiSettingsMemberInfo settingsObjectInfo = new();
+                //MauiSettingsInfo settingsInfo = new();
                 return declaredMembers?.ToList();
             }
         }
@@ -503,8 +502,7 @@ namespace AndreasReitberger.Maui
             if (settingsObjectInfo.Info is not null)
             {
                 List<MauiSettingAttribute> settingBaseAttributes
-                    = settingsObjectInfo.Info.GetCustomAttributes<MauiSettingAttribute>(inherit: false)
-                    .ToList();
+                    = [.. settingsObjectInfo.Info.GetCustomAttributes<MauiSettingAttribute>(inherit: false)];
                 if (settingBaseAttributes.Count == 0)
                 {
                     // If the member has not the needed MauiSettingsAttribute, continue with the search
@@ -527,7 +525,6 @@ namespace AndreasReitberger.Maui
 #endif
                     case MauiSettingsTarget.Local:
                     default:
-                        //settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.Default);
                         settingsInfo.Value = MauiSettingsHelper.GetSettingsValue(settingsInfo.Name, settingsInfo.SettingsType, settingsInfo.Default);
                         break;
 
@@ -662,8 +659,7 @@ namespace AndreasReitberger.Maui
             if (settingsObjectInfo.Info is not null)
             {
                 List<MauiSettingAttribute> settingBaseAttributes
-                    = settingsObjectInfo.Info.GetCustomAttributes<MauiSettingAttribute>(inherit: false)
-                    .ToList();
+                    = [.. settingsObjectInfo.Info.GetCustomAttributes<MauiSettingAttribute>(inherit: false)];
                 if (settingBaseAttributes?.Count == 0)
                 {
                     // If the member has not the needed MauiSettingsAttribute, continue with the search
@@ -971,8 +967,7 @@ namespace AndreasReitberger.Maui
             if (settingsObjectInfo.Info is not null)
             {
                 List<MauiSettingAttribute> settingBaseAttributes
-                    = settingsObjectInfo.Info.GetCustomAttributes<MauiSettingAttribute>(inherit: false)
-                    .ToList();
+                    = [.. settingsObjectInfo.Info.GetCustomAttributes<MauiSettingAttribute>(inherit: false)];
                 if (settingBaseAttributes?.Count == 0)
                 {
                     // If the member has not the needed MauiSettingsAttribute, continue with the search


### PR DESCRIPTION
This commit removes the old nuget `Microsoft.Maui.Controls.Compatibility`. Also all nugets have been updated.

Fixed #79
Fixed #80