### PR TITLE
Removed `WindowsSdkPackageVersion` workaround

### DIFF
--- a/framework.maui.props
+++ b/framework.maui.props
@@ -7,8 +7,8 @@
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
-		<WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>
+		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> 
+		<WindowsSdkPackageVersion>10.0.19041.41</WindowsSdkPackageVersion>-->
 
 		<!-- General -->
 		<UseMaui>true</UseMaui>
@@ -17,12 +17,15 @@
 		<PublishReadyToRun>false</PublishReadyToRun>
 		<IsRidAgnostic Condition="'$(OutputType)' == 'Library'">true</IsRidAgnostic>
 
-		<!-- Needed with latest SDK 8 version? -->
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<!-- Needed with latest SDK 8 version?
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks> -->
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<!-- Needed for Dependabot to work?! 
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">35.0</TargetPlatformMinVersion>
+		-->
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>

--- a/src/MauiSettings.Example/MauiSettings.Example.csproj
+++ b/src/MauiSettings.Example/MauiSettings.Example.csproj
@@ -34,8 +34,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.81" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MauiSettings/MauiSettings.csproj
+++ b/src/MauiSettings/MauiSettings.csproj
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.81" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.9" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Also removed the workaround for `AllowUnsafeBlocks`.

Fixed #85